### PR TITLE
Foo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # NewPkg
+asljasdlasj


### PR DESCRIPTION
The next Documenter release (0.20) will have breaking changes to the `makedocs` and
`deploydocs` API. This PR makes sure that the Travis CI runs will install and use Documenter
0.19 until you have had the chance to update the `make.jl` script.

Subscribe to JuliaDocs/Documenter.jl#XXX to be notified of when 0.20 is released and you can
upgrade you `make.jl` scripts. Note that the conversation in that issue is locked, so you
should not receive any other notifications from that there.

If there you see a problem with the PR, please tag @mortenpi.
