### PR TITLE
Cap Documenter.jl to 0.19 on Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # NewPkg
+asljasdlasj


### PR DESCRIPTION
The next Documenter release (0.20) will have breaking changes to the `makedocs` and `deploydocs` API. This PR makes sure that the Travis CI runs will install and use Documenter 0.19 until you have had the chance to update the `make.jl` script.

Subscribe to JuliaDocs/Documenter.jl#XXX to be notified about the 0.20 release. The release will have release notes detailing how to upgrade your `make.jl` script. Note that the conversation in that issue is locked, so you should not receive any other notifications from that there.

If there you see a problem with the PR, please tag @mortenpi.

mortenpi/NewPkg.jl#1
